### PR TITLE
Omit advanced optimizations for browser target

### DIFF
--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -13,8 +13,7 @@
                       :js-options {:js-provider    :external
                                    :external-index "target/index.js"}
                       :modules    {:main {:init-fn app.core/main}}
-                      :devtools   {:after-load app.core/main}
-                      :release    {:compiler-options {:optimizations :advanced}}}
+                      :devtools   {:after-load app.core/main}}
             :stories {:target     :npm-module
                       :entries    [app.stories.core]
                       :output-dir "public/js/stories"}}}


### PR DESCRIPTION
Hi

It's possible to remove ":optimizations :advanced" from the compiler-options because it's already the default level for the browser target when releasing. 

> The release output will be minified by the Closure Compiler with :advanced optimizations

Src: https://shadow-cljs.github.io/docs/UsersGuide.html#target-browser